### PR TITLE
docs(i18n): mirror 4-spoke multi-CLI migration into ko/ja/zh READMEs

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -38,7 +38,7 @@
 
 その結果、このリポジトリは agent、skill、rule、MCP 設定、orchestration pattern をまとめて提供します。可能なものは portable に、Copilot の強みが重要な部分は Copilot-native に設計しています。
 
-> このリポジトリの community pattern が Claude Code、Codex CLI、Gemini CLI のような外部 specialist worker をどう連携させるかは [Multi-AI Orchestration](#multi-ai-orchestration-) を参照してください。
+> このリポジトリの community pattern が Claude Code、Codex CLI、Cursor CLI、Antigravity CLI (`agy`) のような外部 specialist worker をどう連携させるかは [Multi-AI Orchestration](#multi-ai-orchestration-) を参照してください。
 
 ---
 
@@ -47,7 +47,7 @@
 | 原則 | 実際の意味 |
 |------|------------|
 | **GitHub を system of record にする** | すべての workflow は GitHub で始まり GitHub で終わります。Issue は task 入力、PR は agent 出力、Actions は observability layer です。 |
-| **Copilot CLI を orchestration hub にする** | Copilot は単に code を生成するだけでなく specialist を調整します。Claude は深い reasoning、Codex は高速生成、Gemini は visual analysis を担当し、Copilot はそれを routing・synthesis します。 |
+| **Copilot CLI を orchestration hub にする** | Copilot は単に code を生成するだけでなく specialist を調整します。Claude は深い reasoning、Codex は高速生成、Cursor は IDE 共有 context を活かした repo-aware な編集、Antigravity (`agy`) はマルチモデル／マルチモーダル分析を担当し、Copilot はそれを routing・synthesis します。 |
 | **model choice は loyalty ではなく routing** | すべての task に最適な単一 model はありません。このリポジトリの skill と pattern は subtask ごとに最適な model へルーティングする前提で設計されています。 |
 | **Portable core, Copilot-native layer** | 多くの skill は agentskills.io 互換 runtime ならどこでも動作します。Copilot 専用機能は `skills/copilot-exclusive/` に分離され、native Copilot 依存が明確です。 |
 
@@ -61,7 +61,7 @@ Copilot CLI が multi-AI 開発 workflow のハブとして強い理由は、次
 
 **Multi-model routing** — 同じ session の中で `/model` や agent ごとの override を使い、GPT、Claude、Gemini 系 model を切り替えられます。architecture には高性能 reasoning model、boilerplate には高速 model、triage には低コスト model を選ぶ、といった運用が可能です。
 
-**Orchestration primitives** — Plan Mode、Autopilot、Fleet、Background Delegation、組み込み SQLite session DB が、複雑な multi-agent workflow の building block になります。別の specialist tool が適切なら、このリポジトリの orchestration pattern で Codex CLI、Claude Code、Gemini CLI に委任し、結果を GitHub に戻せます。
+**Orchestration primitives** — Plan Mode、Autopilot、Fleet、Background Delegation、組み込み SQLite session DB が、複雑な multi-agent workflow の building block になります。別の specialist tool が適切なら、このリポジトリの orchestration pattern で Codex CLI、Claude Code、Cursor CLI、Antigravity CLI (`agy`) に委任し、結果を GitHub に戻せます。
 
 <details>
 <summary>フル機能リファレンス（11項目）</summary>
@@ -78,7 +78,7 @@ Copilot CLI が multi-AI 開発 workflow のハブとして強い理由は、次
 | 8 | **Session SQL Database** | session ごとに組み込み SQLite を利用でき、構造化データ、todo 追跡、状態管理が可能です。 |
 | 9 | **Cross-Session Memory** | `session_store` で以前の session 履歴を検索し、再利用できます。 |
 | 10 | **LSP のファーストクラスサポート** | Language Server Protocol 統合により、高精度な code intelligence を実現します。 |
-| 11 | **Multi-AI Orchestrator** | Copilot をメタハブとして Claude Code、Codex、Gemini CLI をオーケストレーションできます。_(community pattern)_ |
+| 11 | **Multi-AI Orchestrator** | Copilot をメタハブとして Claude Code、Codex、Cursor CLI、Antigravity (`agy`) をオーケストレーションできます。_(community pattern)_ |
 
 </details>
 
@@ -454,24 +454,25 @@ GitHub Copilot CLI 固有の機能を活用する skill です。
 >
 > **Copilot-native**: GitHub MCP、`/model` 切り替え、Plan Mode、Autopilot、Fleet、Background Agents、Session SQL database は Copilot CLI に組み込まれています。
 >
-> **Community pattern**: Claude Code、Codex CLI、Gemini CLI との cross-tool orchestration は、このリポジトリが shell/MCP/pipeline ベースの workflow pattern として文書化したものです。外部 CLI の導入に依存し、Copilot の公式組み込み機能ではありません。
+> **Community pattern**: Claude Code、Codex CLI、Cursor CLI、Antigravity CLI (`agy`) との cross-tool orchestration は、このリポジトリが shell/MCP/pipeline ベースの workflow pattern として文書化したものです。外部 CLI の導入に依存し、Copilot の公式組み込み機能ではありません。
 
 ### アイデア
 
-1つの AI がすべてに最適とは限りません。Claude は推論、Codex は高速実装、Gemini はマルチモーダル理解、Copilot は GitHub 統合に強みがあります。これら **すべて** を1か所から使えたらどうでしょうか。
+1つの AI がすべてに最適とは限りません。Claude は推論、Codex は高速実装、Cursor は repo-aware な multi-file editing、Antigravity (`agy`) はマルチモデル／マルチモーダル分析、Copilot は GitHub 統合に強みがあります。これら **すべて** を1か所から使えたらどうでしょうか。
 
 ```text
-┌──────────────────────────────────────────────────┐
-│                GitHub Copilot CLI                │
-│            (Orchestrator / Meta-Hub)             │
-├──────────────────────────────────────────────────┤
-│                                                  │
-│  ┌────────────┐  ┌────────────┐  ┌────────────┐  │
-│  │ Claude Code│  │  Codex CLI │  │ Gemini CLI │  │
-│  │ (Reasoning)│  │(Impl./Gen.)│  │(Multimodal)│  │
-│  └────────────┘  └────────────┘  └────────────┘  │
-│                                                  │
-└──────────────────────────────────────────────────┘
+┌────────────────────────────────────────────────────────────────┐
+│                       GitHub Copilot CLI                        │
+│                   (Orchestrator / Meta-Hub)                     │
+├────────────────────────────────────────────────────────────────┤
+│                                                                  │
+│  ┌────────────┐  ┌────────────┐  ┌────────────┐  ┌────────────┐ │
+│  │ Claude Code│  │  Codex CLI │  │ Cursor CLI │  │ Antigravity│ │
+│  │   (推論)   │  │   (実装)   │  │ (repo編集) │  │(agy・multi-│ │
+│  │            │  │            │  │            │  │model/vision│ │
+│  └────────────┘  └────────────┘  └────────────┘  └────────────┘ │
+│                                                                  │
+└────────────────────────────────────────────────────────────────┘
 ```
 
 ### 5つのオーケストレーションパターン（Pattern 1〜5：cross-AI）
@@ -504,7 +505,8 @@ GitHub Copilot CLI 固有の機能を活用する skill です。
 | **Copilot CLI** | GitHub 統合 · マルチモデル柔軟性 · オーケストレーション | メタハブ / coordinator |
 | **Claude Code** | 深い推論 · 大規模 context 分析 | 推論 specialist |
 | **Codex CLI** | 高速 code 生成 · boilerplate | 実装 specialist |
-| **Gemini CLI** | マルチモーダル理解 · 視覚分析 | vision / マルチモーダル specialist |
+| **Cursor CLI** | Repo-aware な multi-file editing · IDE-shared context · headless JSON/CI | Repo-aware editor |
+| **Antigravity CLI (`agy`)** | Multi-model backend (Gemini 3.x/Claude/GPT-OSS) · multimodal · Google grounding · background subagents | Multi-model / multimodal specialist |
 
 ### 参考情報と実証済みフレームワーク
 
@@ -536,7 +538,7 @@ Copilot CLI は GitHub workflow に最適化されて設計されています。
 | **Session SQL Database** | session ごとの組み込み SQLite で構造化状態と todo を管理します |
 | **Cross-Session Memory** | `session_store` と `/resume` で以前の session 履歴を検索し、再利用します |
 | **LSP Integration** | Language Server Protocol により symbol-aware な高精度 code intelligence を提供します |
-| **Multi-AI Orchestration** | 単一ハブから Claude Code、Codex、Gemini CLI を連携します _(community pattern)_ |
+| **Multi-AI Orchestration** | 単一ハブから Claude Code、Codex、Cursor CLI、Antigravity (`agy`) を連携します _(community pattern)_ |
 
 > 各機能の詳細は [Copilot Exclusive Features guide](guides/copilot-exclusive-features.md) を参照してください。
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -38,7 +38,7 @@
 
 결과적으로 이 저장소는 에이전트, 스킬, 규칙, MCP 설정, 오케스트레이션 패턴을 함께 제공하는 컬렉션이 됩니다. 가능한 곳에서는 portable하게, 핵심 강점이 걸린 곳에서는 Copilot-native하게 설계합니다.
 
-> 이 저장소의 community pattern이 Claude Code, Codex CLI, Gemini CLI 같은 외부 specialist worker를 어떻게 조율하는지는 [Multi-AI Orchestration](#multi-ai-orchestration-) 섹션을 참고하세요.
+> 이 저장소의 community pattern이 Claude Code, Codex CLI, Cursor CLI, Antigravity CLI (`agy`) 같은 외부 specialist worker를 어떻게 조율하는지는 [Multi-AI Orchestration](#multi-ai-orchestration-) 섹션을 참고하세요.
 
 ---
 
@@ -47,7 +47,7 @@
 | 원칙 | 실제 의미 |
 |------|----------|
 | **GitHub를 시스템 기준점으로** | 모든 워크플로우는 GitHub에서 시작하고 끝납니다. 이슈는 task 입력이고, PR은 에이전트 출력이며, Actions는 관찰 계층입니다. |
-| **Copilot CLI를 오케스트레이션 허브로** | Copilot은 단순히 코드를 생성하는 도구가 아니라 전문가를 조율하는 허브입니다. Claude는 깊이 추론하고, Codex는 빠르게 생성하며, Gemini는 시각 자료를 분석합니다. Copilot은 이를 라우팅하고 합성합니다. |
+| **Copilot CLI를 오케스트레이션 허브로** | Copilot은 단순히 코드를 생성하는 도구가 아니라 specialist를 조율하는 허브입니다. Claude는 깊이 추론하고, Codex는 빠르게 생성하며, Cursor는 IDE와 컨텍스트를 공유한 상태로 repo를 편집하고, Antigravity (`agy`)는 멀티모델/멀티모달 분석을 맡습니다. Copilot은 이를 라우팅하고 합성합니다. |
 | **모델 선택은 라우팅이지 충성도가 아니다** | 모든 task를 가장 잘 처리하는 단일 모델은 없습니다. 이 저장소의 스킬과 패턴은 각 subtask를 가장 적합한 모델로 라우팅하도록 설계되었습니다. |
 | **포터블 코어, Copilot-native 레이어** | 대부분의 스킬은 agentskills.io 호환 런타임 어디서나 작동합니다. Copilot 전용 기능은 `skills/copilot-exclusive/`에 분리되어 있어 native Copilot 의존 여부를 명확히 알 수 있습니다. |
 
@@ -61,7 +61,7 @@ Copilot CLI가 multi-AI 개발 워크플로우의 허브로 강한 이유는 세
 
 **멀티모델 라우팅** — 같은 세션 안에서 `/model`이나 에이전트별 override로 GPT, Claude, Gemini 계열을 바꿔 쓸 수 있습니다. 아키텍처에는 고성능 추론 모델, 보일러플레이트에는 빠른 모델, 트리아지에는 저비용 모델을 고르는 식입니다.
 
-**오케스트레이션 프리미티브** — Plan Mode, Autopilot, Fleet, Background Delegation, 내장 SQLite 세션 DB가 복잡한 multi-agent 워크플로우의 빌딩 블록을 제공합니다. 별도 specialist tool이 더 맞는 경우에는 이 저장소의 오케스트레이션 패턴으로 Codex CLI, Claude Code, Gemini CLI에 위임하고 결과를 다시 GitHub로 연결할 수 있습니다.
+**오케스트레이션 프리미티브** — Plan Mode, Autopilot, Fleet, Background Delegation, 내장 SQLite 세션 DB가 복잡한 multi-agent 워크플로우의 빌딩 블록을 제공합니다. 별도 specialist tool이 더 맞는 경우에는 이 저장소의 오케스트레이션 패턴으로 Codex CLI, Claude Code, Cursor CLI, Antigravity CLI (`agy`)에 위임하고 결과를 다시 GitHub로 연결할 수 있습니다.
 
 <details>
 <summary>전체 기능 레퍼런스 (11개)</summary>
@@ -78,7 +78,7 @@ Copilot CLI가 multi-AI 개발 워크플로우의 허브로 강한 이유는 세
 | 8 | **Session SQL Database** | 세션별 내장 SQLite — 구조화된 데이터, 할일 추적, 상태 관리 |
 | 9 | **Cross-Session Memory** | `session_store`로 이전 세션 기록을 검색하고 재사용 |
 | 10 | **LSP 퍼스트클래스 지원** | Language Server Protocol 통합으로 정밀한 코드 인텔리전스 |
-| 11 | **Multi-AI Orchestrator** | Copilot을 메타 허브로 삼아 Claude Code, Codex, Gemini CLI를 통합 조율 _(community pattern)_ |
+| 11 | **Multi-AI Orchestrator** | Copilot을 메타 허브로 삼아 Claude Code, Codex, Cursor CLI, Antigravity (`agy`)를 통합 조율 _(community pattern)_ |
 
 </details>
 
@@ -454,24 +454,25 @@ Multi-AI Orchestration 시스템 (아래 [전용 섹션](#multi-ai-orchestration
 >
 > **Copilot-native**: GitHub MCP, `/model` 전환, Plan Mode, Autopilot, Fleet, Background Agents, Session SQL database는 Copilot CLI에 내장된 기능입니다.
 >
-> **Community pattern**: Claude Code, Codex CLI, Gemini CLI와의 크로스-툴 오케스트레이션은 이 저장소가 shell/MCP/pipeline 기반 워크플로 패턴으로 문서화한 것입니다. 외부 CLI 설치에 의존하며 Copilot의 공식 내장 기능은 아닙니다.
+> **Community pattern**: Claude Code, Codex CLI, Cursor CLI, Antigravity CLI (`agy`)와의 크로스-툴 오케스트레이션은 이 저장소가 shell/MCP/pipeline 기반 워크플로 패턴으로 문서화한 것입니다. 외부 CLI 설치에 의존하며 Copilot의 공식 내장 기능은 아닙니다.
 
 ### 핵심 아이디어
 
-모든 일을 가장 잘하는 단일 AI는 없습니다. Claude는 추론에, Codex는 빠른 구현에, Gemini는 멀티모달 이해에, Copilot은 GitHub 통합에 강합니다. 이 모든 것을 **한 곳에서** 쓸 수 있다면 어떨까요?
+모든 일을 가장 잘하는 단일 AI는 없습니다. Claude는 추론에, Codex는 빠른 구현에, Cursor는 repo-aware 멀티 파일 편집에, Antigravity (`agy`)는 멀티모델/멀티모달 분석에, Copilot은 GitHub 통합에 강합니다. 이 모든 것을 **한 곳에서** 쓸 수 있다면 어떨까요?
 
 ```text
-┌──────────────────────────────────────────────────┐
-│                GitHub Copilot CLI                │
-│            (Orchestrator / 메타 허브)            │
-├──────────────────────────────────────────────────┤
-│                                                  │
-│  ┌────────────┐  ┌────────────┐  ┌────────────┐  │
-│  │ Claude Code│  │  Codex CLI │  │ Gemini CLI │  │
-│  │   (추론)   │  │   (구현)   │  │ (멀티모달) │  │
-│  └────────────┘  └────────────┘  └────────────┘  │
-│                                                  │
-└──────────────────────────────────────────────────┘
+┌────────────────────────────────────────────────────────────────┐
+│                       GitHub Copilot CLI                        │
+│                   (Orchestrator / 메타 허브)                    │
+├────────────────────────────────────────────────────────────────┤
+│                                                                  │
+│  ┌────────────┐  ┌────────────┐  ┌────────────┐  ┌────────────┐ │
+│  │ Claude Code│  │  Codex CLI │  │ Cursor CLI │  │ Antigravity│ │
+│  │   (추론)   │  │   (구현)   │  │ (Repo 편집)│  │(agy·멀티모델/│ │
+│  │            │  │            │  │            │  │   비전)    │ │
+│  └────────────┘  └────────────┘  └────────────┘  └────────────┘ │
+│                                                                  │
+└────────────────────────────────────────────────────────────────┘
 ```
 
 ### 5가지 크로스-AI 오케스트레이션 패턴
@@ -504,7 +505,8 @@ Multi-AI Orchestration 시스템 (아래 [전용 섹션](#multi-ai-orchestration
 | **Copilot CLI** | GitHub 통합 · 멀티 모델 유연성 · 오케스트레이션 | 메타 허브 / 조율자 |
 | **Claude Code** | 심층 추론 · 대규모 컨텍스트 분석 | 추론 전문가 |
 | **Codex CLI** | 빠른 코드 생성 · 보일러플레이트 | 구현 전문가 |
-| **Gemini CLI** | 멀티모달 이해 · 시각 분석 | 비전 / 멀티모달 전문가 |
+| **Cursor CLI** | Repo-aware 멀티 파일 편집 · IDE 공유 컨텍스트 · headless JSON/CI | Repo-aware 에디터 |
+| **Antigravity CLI (`agy`)** | 멀티모델 백엔드 (Gemini 3.x/Claude/GPT-OSS) · 멀티모달 · Google grounding · background subagents | 멀티모델 / 멀티모달 specialist |
 
 ### 참고 프레임워크
 
@@ -536,7 +538,7 @@ Copilot CLI는 GitHub 워크플로우를 중심으로 설계된 도구입니다.
 | **Session SQL Database** | 세션별 내장 SQLite — 구조화된 상태 관리 및 할일 추적 |
 | **Cross-Session Memory** | `session_store`와 `/resume`으로 이전 세션 기록 검색 및 재사용 |
 | **LSP 통합** | 심볼 인식 기반의 정밀한 코드 인텔리전스 |
-| **Multi-AI Orchestration** | 단일 허브에서 Claude Code, Codex, Gemini CLI 통합 조율 _(community pattern)_ |
+| **Multi-AI Orchestration** | 단일 허브에서 Claude Code, Codex, Cursor CLI, Antigravity (`agy`) 통합 조율 _(community pattern)_ |
 
 > 각 기능에 대한 심층 안내는 [Copilot 전용 기능 가이드](guides/copilot-exclusive-features.md)를 참고하세요.
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -38,7 +38,7 @@
 
 因此，这个仓库提供的是一整套 agents、skills、rules、MCP 配置与 orchestration patterns：能 portable 的部分保持 portable，需要原生能力的部分则明确采用 Copilot-native 方式。
 
-> 若想了解本仓库的 community patterns 如何协调 Claude Code、Codex CLI、Gemini CLI 等外部 specialist workers，请参见 [多AI协同编排](#多ai协同编排-)。
+> 若想了解本仓库的 community patterns 如何协调 Claude Code、Codex CLI、Cursor CLI 与 Antigravity CLI（`agy`）等外部 specialist workers，请参见 [多AI协同编排](#多ai协同编排-)。
 
 ---
 
@@ -47,7 +47,7 @@
 | 原则 | 实际含义 |
 |------|----------|
 | **GitHub 作为 system of record** | 所有 workflow 都从 GitHub 开始并回到 GitHub。Issue 是任务输入，PR 是 agent 输出，Actions 是观测层。 |
-| **Copilot CLI 作为 orchestration hub** | Copilot 不只是生成代码，而是协调 specialist。Claude 擅长深度推理，Codex 擅长快速生成，Gemini 擅长视觉分析；Copilot 负责路由与综合。 |
+| **Copilot CLI 作为 orchestration hub** | Copilot 不只是生成代码，而是协调 specialist。Claude 擅长深度推理，Codex 擅长快速生成，Cursor 擅长基于 IDE 共享上下文进行 repo-aware 编辑，Antigravity（`agy`）覆盖 multi-model / multimodal 分析；Copilot 负责路由与综合。 |
 | **模型选择是 routing，不是 loyalty** | 没有一个单一模型能赢下所有任务。本仓库中的 skills 与 patterns 都围绕“把子任务路由给最合适的模型”来设计。 |
 | **Portable core, Copilot-native layer** | 大多数 skills 都可运行在 agentskills.io 兼容 runtime 中。Copilot 专属能力被明确隔离在 `skills/copilot-exclusive/` 下，因此你始终知道哪些部分依赖原生 Copilot 能力。 |
 
@@ -61,7 +61,7 @@
 
 **多模型路由** —— 在同一会话里，可以通过 `/model` 或按 agent 覆盖来切换 GPT、Claude、Gemini 等模型家族。架构任务用高阶推理模型，样板代码用快速模型，分诊用低成本模型。
 
-**编排原语** —— Plan Mode、Autopilot、Fleet、Background Delegation 以及内置 SQLite session DB，提供了构建复杂 multi-agent workflow 的基础部件。当外部 specialist tool 更适合时，本仓库的 orchestration patterns 也说明了如何把任务委派给 Codex CLI、Claude Code 或 Gemini CLI，并把结果重新带回 GitHub。
+**编排原语** —— Plan Mode、Autopilot、Fleet、Background Delegation 以及内置 SQLite session DB，提供了构建复杂 multi-agent workflow 的基础部件。当外部 specialist tool 更适合时，本仓库的 orchestration patterns 也说明了如何把任务委派给 Codex CLI、Claude Code、Cursor CLI 或 Antigravity CLI（`agy`），并把结果重新带回 GitHub。
 
 <details>
 <summary>完整能力参考（11 项）</summary>
@@ -78,7 +78,7 @@
 | 8 | **Session SQL Database** | 内置每会话 SQLite，用于结构化数据、todo 跟踪与状态管理。 |
 | 9 | **Cross-Session Memory** | 通过 `session_store` 检索并复用过往会话历史。 |
 | 10 | **LSP First-Class Support** | 集成 Language Server Protocol，提供精准代码智能。 |
-| 11 | **Multi-AI Orchestrator** | 以 Copilot 为元枢纽，编排 Claude Code、Codex、Gemini CLI。_(community pattern)_ |
+| 11 | **Multi-AI Orchestrator** | 以 Copilot 为元枢纽，编排 Claude Code、Codex、Cursor CLI 与 Antigravity（`agy`）。_(community pattern)_ |
 
 </details>
 
@@ -454,24 +454,25 @@ everything-copilot-cli/
 >
 > **Copilot-native**：GitHub MCP、`/model` 切换、Plan Mode、Autopilot、Fleet、Background Agents 与 Session SQL database 都是 Copilot CLI 内建能力。
 >
-> **Community pattern**：与 Claude Code、Codex CLI、Gemini CLI 的跨工具协同，是本仓库记录的 shell/MCP/pipeline 工作流模式。它依赖外部 CLI 已安装，并不是 Copilot 的官方内置能力。
+> **Community pattern**：与 Claude Code、Codex CLI、Cursor CLI 和 Antigravity CLI（`agy`）的跨工具协同，是本仓库记录的 shell/MCP/pipeline 工作流模式。它依赖外部 CLI 已安装，并不是 Copilot 的官方内置能力。
 
 ### 核心思路
 
-没有任何单一 AI 在所有场景都最优。Claude 擅长推理，Codex 擅长快速实现，Gemini 擅长多模态理解，而 Copilot 擅长 GitHub 集成。那如果你能在一个地方使用**它们全部**呢？
+没有任何单一 AI 在所有场景都最优。Claude 擅长推理，Codex 擅长快速实现，Cursor 擅长基于 repo 上下文的多文件编辑，Antigravity（`agy`）擅长 multi-model / multimodal 分析，而 Copilot 擅长 GitHub 集成。那如果你能在一个地方使用**它们全部**呢？
 
 ```text
-┌──────────────────────────────────────────────────┐
-│                GitHub Copilot CLI                │
-│            (Orchestrator / Meta-Hub)             │
-├──────────────────────────────────────────────────┤
-│                                                  │
-│  ┌────────────┐  ┌────────────┐  ┌────────────┐  │
-│  │ Claude Code│  │  Codex CLI │  │ Gemini CLI │  │
-│  │ (Reasoning)│  │(Impl./Gen.)│  │(Multimodal)│  │
-│  └────────────┘  └────────────┘  └────────────┘  │
-│                                                  │
-└──────────────────────────────────────────────────┘
+┌────────────────────────────────────────────────────────────────┐
+│                       GitHub Copilot CLI                       │
+│                   (Orchestrator / Meta-Hub)                    │
+├────────────────────────────────────────────────────────────────┤
+│                                                                │
+│  ┌────────────┐  ┌────────────┐  ┌────────────┐  ┌────────────┐ │
+│  │ Claude Code│  │  Codex CLI │  │ Cursor CLI │  │ Antigravity│ │
+│  │   (推理)   │  │  (实现)    │  │(Repo 编辑) │  │(agy·multi- │ │
+│  │            │  │            │  │            │  │model/vision│ │
+│  └────────────┘  └────────────┘  └────────────┘  └────────────┘ │
+│                                                                │
+└────────────────────────────────────────────────────────────────┘
 ```
 
 ### 5 种编排模式（模式 1–5：跨 AI）
@@ -504,7 +505,8 @@ everything-copilot-cli/
 | **Copilot CLI** | GitHub 集成 · 多模型灵活性 · 编排 | 元枢纽 / 协调者 |
 | **Claude Code** | 深度推理 · 大上下文分析 | 推理专家 |
 | **Codex CLI** | 快速代码生成 · 样板代码 | 实现专家 |
-| **Gemini CLI** | 多模态理解 · 视觉分析 | 视觉 / 多模态专家 |
+| **Cursor CLI** | Repo-aware 多文件编辑 · IDE 共享上下文 · headless JSON/CI | Repo-aware 编辑器 |
+| **Antigravity CLI (`agy`)** | Multi-model backend（Gemini 3.x / Claude / GPT-OSS）· multimodal · Google grounding · background subagents | Multi-model / multimodal specialist |
 
 ### 参考与验证过的框架
 
@@ -536,7 +538,7 @@ Copilot CLI 围绕你的 GitHub 工作流而构建。以下能力开箱即用：
 | **Session SQL Database** | 每会话内置 SQLite，用于结构化状态与 todo 跟踪 |
 | **Cross-Session Memory** | 通过 `session_store` 与 `/resume` 检索并复用过往会话历史 |
 | **LSP Integration** | Language Server Protocol 提供精准、符号感知的代码智能 |
-| **Multi-AI Orchestration** | 从单一枢纽协调 Claude Code、Codex、Gemini CLI _(community pattern)_ |
+| **Multi-AI Orchestration** | 从单一枢纽协调 Claude Code、Codex、Cursor CLI 与 Antigravity（`agy`）_(community pattern)_ |
 
 > 详见 [Copilot Exclusive Features guide](guides/copilot-exclusive-features.md) 以深入了解每项能力。
 


### PR DESCRIPTION
## Summary

Follow-up to the merged multi-CLI refresh (#7). Mirrors the EN README.md 'Claude Code + Codex CLI + Gemini CLI' (3-spoke) -> 'Claude Code + Codex CLI + Cursor CLI + Antigravity CLI (agy)' (4-spoke) migration into README.ko.md, README.ja.md, and README.zh.md: 9 locations each (intro callout, design-principles row, orchestration-primitives paragraph, capability table row, community-pattern callout, 'The Idea' prose, ASCII diagram, Tool Specialization table, closing capability table row).

Embedded/native Copilot model-name mentions (e.g. Gemini 3.1 Pro, the Gemini 3.x backend note inside the Antigravity row) are preserved untouched per repo convention.

\guides/the-beginner-skills-tutorial.{ko,ja,zh}.md\ contain no Gemini CLI references and needed no changes (verified via grep).

## Validation
- Repo-wide grep for 'Gemini CLI' in translation files: 0 remaining
- \
pm test\: 1062 passed
- \
pm run validate\ / \
pm run lint:md\: clean

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>