### PR TITLE
docs: replace machine-specific paths with neutral ones

### DIFF
--- a/guides/the-beginner-skills-tutorial.ja.md
+++ b/guides/the-beginner-skills-tutorial.ja.md
@@ -47,7 +47,7 @@ category: guide
 以下のコマンドでは必要に応じてこの path を置き換えてください。
 
 ```text
-C:\work-copilot\test
+C:\copilot-lab
 ```
 
 ---
@@ -57,7 +57,7 @@ C:\work-copilot\test
 新しい PowerShell window で実行します。
 
 ```powershell
-New-Item -ItemType Directory -Force C:\work-copilot\test\skills-lab-template | Out-Null
+New-Item -ItemType Directory -Force C:\copilot-lab\skills-lab-template | Out-Null
 ```
 
 ---
@@ -67,9 +67,9 @@ New-Item -ItemType Directory -Force C:\work-copilot\test\skills-lab-template | O
 `everything-copilot-cli` の repository root で実行します。
 
 ```powershell
-cd C:\work-copilot\everything-copilot-cli
+cd (git rev-parse --show-toplevel)
 npm install
-npm run setup -- --target C:\work-copilot\test\skills-lab-template --profile recommended
+npm run setup -- --target C:\copilot-lab\skills-lab-template --profile recommended
 ```
 
 インストール結果に次が含まれていれば OK です。
@@ -88,7 +88,7 @@ npm run setup -- --target C:\work-copilot\test\skills-lab-template --profile rec
 まず次を実行します。
 
 ```powershell
-cd C:\work-copilot\test\skills-lab-template
+cd C:\copilot-lab\skills-lab-template
 npm init -y
 npm pkg set scripts.test="node --test"
 New-Item -ItemType Directory -Force src | Out-Null
@@ -143,7 +143,7 @@ npm test
 template project で Copilot を起動します。
 
 ```powershell
-cd C:\work-copilot\test\skills-lab-template
+cd C:\copilot-lab\skills-lab-template
 copilot
 ```
 
@@ -168,10 +168,10 @@ Copilot の中で次を実行します。
 次を実行します。
 
 ```powershell
-Remove-Item C:\work-copilot\test\skills-lab-plain -Recurse -Force -ErrorAction SilentlyContinue
-Remove-Item C:\work-copilot\test\skills-lab-guided -Recurse -Force -ErrorAction SilentlyContinue
-Copy-Item C:\work-copilot\test\skills-lab-template C:\work-copilot\test\skills-lab-plain -Recurse
-Copy-Item C:\work-copilot\test\skills-lab-template C:\work-copilot\test\skills-lab-guided -Recurse
+Remove-Item C:\copilot-lab\skills-lab-plain -Recurse -Force -ErrorAction SilentlyContinue
+Remove-Item C:\copilot-lab\skills-lab-guided -Recurse -Force -ErrorAction SilentlyContinue
+Copy-Item C:\copilot-lab\skills-lab-template C:\copilot-lab\skills-lab-plain -Recurse
+Copy-Item C:\copilot-lab\skills-lab-template C:\copilot-lab\skills-lab-guided -Recurse
 ```
 
 これで 2 つの folder は同じ壊れた初期状態になります。
@@ -185,7 +185,7 @@ Copy-Item C:\work-copilot\test\skills-lab-template C:\work-copilot\test\skills-l
 `skills-lab-plain` で Copilot を起動します。
 
 ```powershell
-cd C:\work-copilot\test\skills-lab-plain
+cd C:\copilot-lab\skills-lab-plain
 copilot
 ```
 
@@ -202,7 +202,7 @@ Copilot がどの順番で進めるかを見てください。
 `skills-lab-guided` で Copilot を起動します。
 
 ```powershell
-cd C:\work-copilot\test\skills-lab-guided
+cd C:\copilot-lab\skills-lab-guided
 copilot
 ```
 
@@ -225,10 +225,10 @@ Tests are failing. Use the systematic-debugging skill. First reproduce the failu
 まず 2 つの folder を初期状態に戻します。
 
 ```powershell
-Remove-Item C:\work-copilot\test\skills-lab-plain -Recurse -Force
-Remove-Item C:\work-copilot\test\skills-lab-guided -Recurse -Force
-Copy-Item C:\work-copilot\test\skills-lab-template C:\work-copilot\test\skills-lab-plain -Recurse
-Copy-Item C:\work-copilot\test\skills-lab-template C:\work-copilot\test\skills-lab-guided -Recurse
+Remove-Item C:\copilot-lab\skills-lab-plain -Recurse -Force
+Remove-Item C:\copilot-lab\skills-lab-guided -Recurse -Force
+Copy-Item C:\copilot-lab\skills-lab-template C:\copilot-lab\skills-lab-plain -Recurse
+Copy-Item C:\copilot-lab\skills-lab-template C:\copilot-lab\skills-lab-guided -Recurse
 ```
 
 ### Folder A — 通常の prompt
@@ -260,10 +260,10 @@ Update divide() so dividing by zero throws an error. Use the tdd-workflow skill:
 もう一度 2 つの folder を初期状態に戻します。
 
 ```powershell
-Remove-Item C:\work-copilot\test\skills-lab-plain -Recurse -Force
-Remove-Item C:\work-copilot\test\skills-lab-guided -Recurse -Force
-Copy-Item C:\work-copilot\test\skills-lab-template C:\work-copilot\test\skills-lab-plain -Recurse
-Copy-Item C:\work-copilot\test\skills-lab-template C:\work-copilot\test\skills-lab-guided -Recurse
+Remove-Item C:\copilot-lab\skills-lab-plain -Recurse -Force
+Remove-Item C:\copilot-lab\skills-lab-guided -Recurse -Force
+Copy-Item C:\copilot-lab\skills-lab-template C:\copilot-lab\skills-lab-plain -Recurse
+Copy-Item C:\copilot-lab\skills-lab-template C:\copilot-lab\skills-lab-guided -Recurse
 ```
 
 ### Folder A — 通常の prompt
@@ -332,8 +332,8 @@ Copilot がインストールした collection を認識していないような
 built-in skill しか見えず project agent もない場合は、次を再実行してください。
 
 ```powershell
-cd C:\work-copilot\everything-copilot-cli
-npm run setup -- --target C:\work-copilot\test\skills-lab-template --profile recommended
+cd (git rev-parse --show-toplevel)
+npm run setup -- --target C:\copilot-lab\skills-lab-template --profile recommended
 ```
 
 ---

--- a/guides/the-beginner-skills-tutorial.ja.md
+++ b/guides/the-beginner-skills-tutorial.ja.md
@@ -67,7 +67,6 @@ New-Item -ItemType Directory -Force C:\copilot-lab\skills-lab-template | Out-Nul
 `everything-copilot-cli` の repository root で実行します。
 
 ```powershell
-cd (git rev-parse --show-toplevel)
 npm install
 npm run setup -- --target C:\copilot-lab\skills-lab-template --profile recommended
 ```
@@ -329,10 +328,9 @@ Copilot がインストールした collection を認識していないような
    - `.github/skills/`
    - `.github/agents/`
 
-built-in skill しか見えず project agent もない場合は、次を再実行してください。
+built-in skill しか見えず project agent もない場合は、`everything-copilot-cli` の repository root に戻って、次を再実行してください。
 
 ```powershell
-cd (git rev-parse --show-toplevel)
 npm run setup -- --target C:\copilot-lab\skills-lab-template --profile recommended
 ```
 

--- a/guides/the-beginner-skills-tutorial.ko.md
+++ b/guides/the-beginner-skills-tutorial.ko.md
@@ -67,7 +67,6 @@ New-Item -ItemType Directory -Force C:\copilot-lab\skills-lab-template | Out-Nul
 `everything-copilot-cli` 저장소 루트에서 실행하세요.
 
 ```powershell
-cd (git rev-parse --show-toplevel)
 npm install
 npm run setup -- --target C:\copilot-lab\skills-lab-template --profile recommended
 ```
@@ -331,10 +330,9 @@ Copilot이 설치한 컬렉션을 못 읽는 것 같다면:
    - `.github/skills/`
    - `.github/agents/`
 
-built-in skills만 보이고 project agents가 안 보이면 아래를 다시 실행하세요.
+built-in skills만 보이고 project agents가 안 보이면 `everything-copilot-cli` 저장소 루트로 돌아가서 아래를 다시 실행하세요.
 
 ```powershell
-cd (git rev-parse --show-toplevel)
 npm run setup -- --target C:\copilot-lab\skills-lab-template --profile recommended
 ```
 

--- a/guides/the-beginner-skills-tutorial.ko.md
+++ b/guides/the-beginner-skills-tutorial.ko.md
@@ -47,7 +47,7 @@ category: guide
 아래 명령에서는 필요하면 이 경로를 바꿔서 사용하세요.
 
 ```text
-C:\work-copilot\test
+C:\copilot-lab
 ```
 
 ---
@@ -57,7 +57,7 @@ C:\work-copilot\test
 새 PowerShell 창에서 실행하세요.
 
 ```powershell
-New-Item -ItemType Directory -Force C:\work-copilot\test\skills-lab-template | Out-Null
+New-Item -ItemType Directory -Force C:\copilot-lab\skills-lab-template | Out-Null
 ```
 
 ---
@@ -67,9 +67,9 @@ New-Item -ItemType Directory -Force C:\work-copilot\test\skills-lab-template | O
 `everything-copilot-cli` 저장소 루트에서 실행하세요.
 
 ```powershell
-cd C:\work-copilot\everything-copilot-cli
+cd (git rev-parse --show-toplevel)
 npm install
-npm run setup -- --target C:\work-copilot\test\skills-lab-template --profile recommended
+npm run setup -- --target C:\copilot-lab\skills-lab-template --profile recommended
 ```
 
 설치 요약에 다음이 보이면 됩니다.
@@ -88,7 +88,7 @@ npm run setup -- --target C:\work-copilot\test\skills-lab-template --profile rec
 먼저 이 명령을 실행하세요.
 
 ```powershell
-cd C:\work-copilot\test\skills-lab-template
+cd C:\copilot-lab\skills-lab-template
 npm init -y
 npm pkg set scripts.test="node --test"
 New-Item -ItemType Directory -Force src | Out-Null
@@ -143,7 +143,7 @@ npm test
 실습 템플릿 프로젝트에서 Copilot을 실행하세요.
 
 ```powershell
-cd C:\work-copilot\test\skills-lab-template
+cd C:\copilot-lab\skills-lab-template
 copilot
 ```
 
@@ -168,10 +168,10 @@ Copilot 안에서 다음을 실행하세요.
 이 명령을 실행하세요.
 
 ```powershell
-Remove-Item C:\work-copilot\test\skills-lab-plain -Recurse -Force -ErrorAction SilentlyContinue
-Remove-Item C:\work-copilot\test\skills-lab-guided -Recurse -Force -ErrorAction SilentlyContinue
-Copy-Item C:\work-copilot\test\skills-lab-template C:\work-copilot\test\skills-lab-plain -Recurse
-Copy-Item C:\work-copilot\test\skills-lab-template C:\work-copilot\test\skills-lab-guided -Recurse
+Remove-Item C:\copilot-lab\skills-lab-plain -Recurse -Force -ErrorAction SilentlyContinue
+Remove-Item C:\copilot-lab\skills-lab-guided -Recurse -Force -ErrorAction SilentlyContinue
+Copy-Item C:\copilot-lab\skills-lab-template C:\copilot-lab\skills-lab-plain -Recurse
+Copy-Item C:\copilot-lab\skills-lab-template C:\copilot-lab\skills-lab-guided -Recurse
 ```
 
 이제 두 폴더는 완전히 같은 시작 상태입니다.
@@ -185,7 +185,7 @@ Copy-Item C:\work-copilot\test\skills-lab-template C:\work-copilot\test\skills-l
 `skills-lab-plain`에서 Copilot을 실행하세요.
 
 ```powershell
-cd C:\work-copilot\test\skills-lab-plain
+cd C:\copilot-lab\skills-lab-plain
 copilot
 ```
 
@@ -202,7 +202,7 @@ Copilot이 어떤 순서로 작업하는지 봅니다.
 `skills-lab-guided`에서 Copilot을 실행하세요.
 
 ```powershell
-cd C:\work-copilot\test\skills-lab-guided
+cd C:\copilot-lab\skills-lab-guided
 copilot
 ```
 
@@ -227,10 +227,10 @@ Tests are failing. Use the systematic-debugging skill. First reproduce the failu
 먼저 두 폴더를 초기 상태로 되돌립니다.
 
 ```powershell
-Remove-Item C:\work-copilot\test\skills-lab-plain -Recurse -Force
-Remove-Item C:\work-copilot\test\skills-lab-guided -Recurse -Force
-Copy-Item C:\work-copilot\test\skills-lab-template C:\work-copilot\test\skills-lab-plain -Recurse
-Copy-Item C:\work-copilot\test\skills-lab-template C:\work-copilot\test\skills-lab-guided -Recurse
+Remove-Item C:\copilot-lab\skills-lab-plain -Recurse -Force
+Remove-Item C:\copilot-lab\skills-lab-guided -Recurse -Force
+Copy-Item C:\copilot-lab\skills-lab-template C:\copilot-lab\skills-lab-plain -Recurse
+Copy-Item C:\copilot-lab\skills-lab-template C:\copilot-lab\skills-lab-guided -Recurse
 ```
 
 ### 폴더 A — 일반 프롬프트
@@ -262,10 +262,10 @@ Update divide() so dividing by zero throws an error. Use the tdd-workflow skill:
 다시 두 폴더를 초기 상태로 되돌립니다.
 
 ```powershell
-Remove-Item C:\work-copilot\test\skills-lab-plain -Recurse -Force
-Remove-Item C:\work-copilot\test\skills-lab-guided -Recurse -Force
-Copy-Item C:\work-copilot\test\skills-lab-template C:\work-copilot\test\skills-lab-plain -Recurse
-Copy-Item C:\work-copilot\test\skills-lab-template C:\work-copilot\test\skills-lab-guided -Recurse
+Remove-Item C:\copilot-lab\skills-lab-plain -Recurse -Force
+Remove-Item C:\copilot-lab\skills-lab-guided -Recurse -Force
+Copy-Item C:\copilot-lab\skills-lab-template C:\copilot-lab\skills-lab-plain -Recurse
+Copy-Item C:\copilot-lab\skills-lab-template C:\copilot-lab\skills-lab-guided -Recurse
 ```
 
 ### 폴더 A — 일반 프롬프트
@@ -334,8 +334,8 @@ Copilot이 설치한 컬렉션을 못 읽는 것 같다면:
 built-in skills만 보이고 project agents가 안 보이면 아래를 다시 실행하세요.
 
 ```powershell
-cd C:\work-copilot\everything-copilot-cli
-npm run setup -- --target C:\work-copilot\test\skills-lab-template --profile recommended
+cd (git rev-parse --show-toplevel)
+npm run setup -- --target C:\copilot-lab\skills-lab-template --profile recommended
 ```
 
 ---

--- a/guides/the-beginner-skills-tutorial.md
+++ b/guides/the-beginner-skills-tutorial.md
@@ -47,7 +47,7 @@ Make sure all of these are true:
 In the commands below, replace this path if needed:
 
 ```text
-C:\work-copilot\test
+C:\copilot-lab
 ```
 
 ---
@@ -57,7 +57,7 @@ C:\work-copilot\test
 Run this from a new PowerShell window:
 
 ```powershell
-New-Item -ItemType Directory -Force C:\work-copilot\test\skills-lab-template | Out-Null
+New-Item -ItemType Directory -Force C:\copilot-lab\skills-lab-template | Out-Null
 ```
 
 ---
@@ -67,9 +67,9 @@ New-Item -ItemType Directory -Force C:\work-copilot\test\skills-lab-template | O
 Run this from the `everything-copilot-cli` repository root:
 
 ```powershell
-cd C:\work-copilot\everything-copilot-cli
+cd (git rev-parse --show-toplevel)
 npm install
-npm run setup -- --target C:\work-copilot\test\skills-lab-template --profile recommended
+npm run setup -- --target C:\copilot-lab\skills-lab-template --profile recommended
 ```
 
 You should see an install summary that includes:
@@ -88,7 +88,7 @@ You should see an install summary that includes:
 Run this:
 
 ```powershell
-cd C:\work-copilot\test\skills-lab-template
+cd C:\copilot-lab\skills-lab-template
 npm init -y
 npm pkg set scripts.test="node --test"
 New-Item -ItemType Directory -Force src | Out-Null
@@ -143,7 +143,7 @@ You should see failures. That is expected.
 Start Copilot in the template project:
 
 ```powershell
-cd C:\work-copilot\test\skills-lab-template
+cd C:\copilot-lab\skills-lab-template
 copilot
 ```
 
@@ -168,10 +168,10 @@ Exit Copilot after the check.
 Run this:
 
 ```powershell
-Remove-Item C:\work-copilot\test\skills-lab-plain -Recurse -Force -ErrorAction SilentlyContinue
-Remove-Item C:\work-copilot\test\skills-lab-guided -Recurse -Force -ErrorAction SilentlyContinue
-Copy-Item C:\work-copilot\test\skills-lab-template C:\work-copilot\test\skills-lab-plain -Recurse
-Copy-Item C:\work-copilot\test\skills-lab-template C:\work-copilot\test\skills-lab-guided -Recurse
+Remove-Item C:\copilot-lab\skills-lab-plain -Recurse -Force -ErrorAction SilentlyContinue
+Remove-Item C:\copilot-lab\skills-lab-guided -Recurse -Force -ErrorAction SilentlyContinue
+Copy-Item C:\copilot-lab\skills-lab-template C:\copilot-lab\skills-lab-plain -Recurse
+Copy-Item C:\copilot-lab\skills-lab-template C:\copilot-lab\skills-lab-guided -Recurse
 ```
 
 Now both folders start from the same broken state.
@@ -185,7 +185,7 @@ Now both folders start from the same broken state.
 Open Copilot in `skills-lab-plain`:
 
 ```powershell
-cd C:\work-copilot\test\skills-lab-plain
+cd C:\copilot-lab\skills-lab-plain
 copilot
 ```
 
@@ -202,7 +202,7 @@ Watch what Copilot does.
 Open another Copilot session in `skills-lab-guided`:
 
 ```powershell
-cd C:\work-copilot\test\skills-lab-guided
+cd C:\copilot-lab\skills-lab-guided
 copilot
 ```
 
@@ -227,10 +227,10 @@ Look for these differences:
 First, reset both folders:
 
 ```powershell
-Remove-Item C:\work-copilot\test\skills-lab-plain -Recurse -Force
-Remove-Item C:\work-copilot\test\skills-lab-guided -Recurse -Force
-Copy-Item C:\work-copilot\test\skills-lab-template C:\work-copilot\test\skills-lab-plain -Recurse
-Copy-Item C:\work-copilot\test\skills-lab-template C:\work-copilot\test\skills-lab-guided -Recurse
+Remove-Item C:\copilot-lab\skills-lab-plain -Recurse -Force
+Remove-Item C:\copilot-lab\skills-lab-guided -Recurse -Force
+Copy-Item C:\copilot-lab\skills-lab-template C:\copilot-lab\skills-lab-plain -Recurse
+Copy-Item C:\copilot-lab\skills-lab-template C:\copilot-lab\skills-lab-guided -Recurse
 ```
 
 ### Folder A — plain prompt
@@ -262,10 +262,10 @@ Update divide() so dividing by zero throws an error. Use the tdd-workflow skill:
 Reset both folders again:
 
 ```powershell
-Remove-Item C:\work-copilot\test\skills-lab-plain -Recurse -Force
-Remove-Item C:\work-copilot\test\skills-lab-guided -Recurse -Force
-Copy-Item C:\work-copilot\test\skills-lab-template C:\work-copilot\test\skills-lab-plain -Recurse
-Copy-Item C:\work-copilot\test\skills-lab-template C:\work-copilot\test\skills-lab-guided -Recurse
+Remove-Item C:\copilot-lab\skills-lab-plain -Recurse -Force
+Remove-Item C:\copilot-lab\skills-lab-guided -Recurse -Force
+Copy-Item C:\copilot-lab\skills-lab-template C:\copilot-lab\skills-lab-plain -Recurse
+Copy-Item C:\copilot-lab\skills-lab-template C:\copilot-lab\skills-lab-guided -Recurse
 ```
 
 ### Folder A — plain prompt
@@ -333,8 +333,8 @@ If Copilot does not seem to see the installed collection:
 If you only see built-in skills and no project agents, re-run:
 
 ```powershell
-cd C:\work-copilot\everything-copilot-cli
-npm run setup -- --target C:\work-copilot\test\skills-lab-template --profile recommended
+cd (git rev-parse --show-toplevel)
+npm run setup -- --target C:\copilot-lab\skills-lab-template --profile recommended
 ```
 
 ---

--- a/guides/the-beginner-skills-tutorial.md
+++ b/guides/the-beginner-skills-tutorial.md
@@ -67,7 +67,6 @@ New-Item -ItemType Directory -Force C:\copilot-lab\skills-lab-template | Out-Nul
 Run this from the `everything-copilot-cli` repository root:
 
 ```powershell
-cd (git rev-parse --show-toplevel)
 npm install
 npm run setup -- --target C:\copilot-lab\skills-lab-template --profile recommended
 ```
@@ -330,10 +329,9 @@ If Copilot does not seem to see the installed collection:
    - `.github/skills/`
    - `.github/agents/`
 
-If you only see built-in skills and no project agents, re-run:
+If you only see built-in skills and no project agents, go back to the `everything-copilot-cli` repository root and re-run:
 
 ```powershell
-cd (git rev-parse --show-toplevel)
 npm run setup -- --target C:\copilot-lab\skills-lab-template --profile recommended
 ```
 

--- a/guides/the-beginner-skills-tutorial.zh.md
+++ b/guides/the-beginner-skills-tutorial.zh.md
@@ -67,7 +67,6 @@ New-Item -ItemType Directory -Force C:\copilot-lab\skills-lab-template | Out-Nul
 在 `everything-copilot-cli` 仓库根目录运行：
 
 ```powershell
-cd (git rev-parse --show-toplevel)
 npm install
 npm run setup -- --target C:\copilot-lab\skills-lab-template --profile recommended
 ```
@@ -329,10 +328,9 @@ Use the planner agent and plan mode. Break this work into tasks with dependencie
    - `.github/skills/`
    - `.github/agents/`
 
-如果你只能看到 built-in skills，看不到 project agents，请重新运行：
+如果你只能看到 built-in skills，看不到 project agents，请返回 `everything-copilot-cli` 仓库根目录并重新运行：
 
 ```powershell
-cd (git rev-parse --show-toplevel)
 npm run setup -- --target C:\copilot-lab\skills-lab-template --profile recommended
 ```
 

--- a/guides/the-beginner-skills-tutorial.zh.md
+++ b/guides/the-beginner-skills-tutorial.zh.md
@@ -47,7 +47,7 @@ category: guide
 下面命令里的这个路径如果需要可以自行替换：
 
 ```text
-C:\work-copilot\test
+C:\copilot-lab
 ```
 
 ---
@@ -57,7 +57,7 @@ C:\work-copilot\test
 在新的 PowerShell 窗口里运行：
 
 ```powershell
-New-Item -ItemType Directory -Force C:\work-copilot\test\skills-lab-template | Out-Null
+New-Item -ItemType Directory -Force C:\copilot-lab\skills-lab-template | Out-Null
 ```
 
 ---
@@ -67,9 +67,9 @@ New-Item -ItemType Directory -Force C:\work-copilot\test\skills-lab-template | O
 在 `everything-copilot-cli` 仓库根目录运行：
 
 ```powershell
-cd C:\work-copilot\everything-copilot-cli
+cd (git rev-parse --show-toplevel)
 npm install
-npm run setup -- --target C:\work-copilot\test\skills-lab-template --profile recommended
+npm run setup -- --target C:\copilot-lab\skills-lab-template --profile recommended
 ```
 
 如果安装摘要里出现下面这些路径，就说明成功了：
@@ -88,7 +88,7 @@ npm run setup -- --target C:\work-copilot\test\skills-lab-template --profile rec
 先运行：
 
 ```powershell
-cd C:\work-copilot\test\skills-lab-template
+cd C:\copilot-lab\skills-lab-template
 npm init -y
 npm pkg set scripts.test="node --test"
 New-Item -ItemType Directory -Force src | Out-Null
@@ -143,7 +143,7 @@ npm test
 在模板项目里启动 Copilot：
 
 ```powershell
-cd C:\work-copilot\test\skills-lab-template
+cd C:\copilot-lab\skills-lab-template
 copilot
 ```
 
@@ -168,10 +168,10 @@ copilot
 运行：
 
 ```powershell
-Remove-Item C:\work-copilot\test\skills-lab-plain -Recurse -Force -ErrorAction SilentlyContinue
-Remove-Item C:\work-copilot\test\skills-lab-guided -Recurse -Force -ErrorAction SilentlyContinue
-Copy-Item C:\work-copilot\test\skills-lab-template C:\work-copilot\test\skills-lab-plain -Recurse
-Copy-Item C:\work-copilot\test\skills-lab-template C:\work-copilot\test\skills-lab-guided -Recurse
+Remove-Item C:\copilot-lab\skills-lab-plain -Recurse -Force -ErrorAction SilentlyContinue
+Remove-Item C:\copilot-lab\skills-lab-guided -Recurse -Force -ErrorAction SilentlyContinue
+Copy-Item C:\copilot-lab\skills-lab-template C:\copilot-lab\skills-lab-plain -Recurse
+Copy-Item C:\copilot-lab\skills-lab-template C:\copilot-lab\skills-lab-guided -Recurse
 ```
 
 现在两个目录都处于完全相同的初始状态。
@@ -185,7 +185,7 @@ Copy-Item C:\work-copilot\test\skills-lab-template C:\work-copilot\test\skills-l
 在 `skills-lab-plain` 中启动 Copilot：
 
 ```powershell
-cd C:\work-copilot\test\skills-lab-plain
+cd C:\copilot-lab\skills-lab-plain
 copilot
 ```
 
@@ -202,7 +202,7 @@ Tests are failing. Fix the bug.
 在 `skills-lab-guided` 中启动 Copilot：
 
 ```powershell
-cd C:\work-copilot\test\skills-lab-guided
+cd C:\copilot-lab\skills-lab-guided
 copilot
 ```
 
@@ -225,10 +225,10 @@ Tests are failing. Use the systematic-debugging skill. First reproduce the failu
 先把两个目录重置回初始状态：
 
 ```powershell
-Remove-Item C:\work-copilot\test\skills-lab-plain -Recurse -Force
-Remove-Item C:\work-copilot\test\skills-lab-guided -Recurse -Force
-Copy-Item C:\work-copilot\test\skills-lab-template C:\work-copilot\test\skills-lab-plain -Recurse
-Copy-Item C:\work-copilot\test\skills-lab-template C:\work-copilot\test\skills-lab-guided -Recurse
+Remove-Item C:\copilot-lab\skills-lab-plain -Recurse -Force
+Remove-Item C:\copilot-lab\skills-lab-guided -Recurse -Force
+Copy-Item C:\copilot-lab\skills-lab-template C:\copilot-lab\skills-lab-plain -Recurse
+Copy-Item C:\copilot-lab\skills-lab-template C:\copilot-lab\skills-lab-guided -Recurse
 ```
 
 ### 目录 A — 普通 prompt
@@ -260,10 +260,10 @@ Update divide() so dividing by zero throws an error. Use the tdd-workflow skill:
 再次把两个目录重置回初始状态：
 
 ```powershell
-Remove-Item C:\work-copilot\test\skills-lab-plain -Recurse -Force
-Remove-Item C:\work-copilot\test\skills-lab-guided -Recurse -Force
-Copy-Item C:\work-copilot\test\skills-lab-template C:\work-copilot\test\skills-lab-plain -Recurse
-Copy-Item C:\work-copilot\test\skills-lab-template C:\work-copilot\test\skills-lab-guided -Recurse
+Remove-Item C:\copilot-lab\skills-lab-plain -Recurse -Force
+Remove-Item C:\copilot-lab\skills-lab-guided -Recurse -Force
+Copy-Item C:\copilot-lab\skills-lab-template C:\copilot-lab\skills-lab-plain -Recurse
+Copy-Item C:\copilot-lab\skills-lab-template C:\copilot-lab\skills-lab-guided -Recurse
 ```
 
 ### 目录 A — 普通 prompt
@@ -332,8 +332,8 @@ Use the planner agent and plan mode. Break this work into tasks with dependencie
 如果你只能看到 built-in skills，看不到 project agents，请重新运行：
 
 ```powershell
-cd C:\work-copilot\everything-copilot-cli
-npm run setup -- --target C:\work-copilot\test\skills-lab-template --profile recommended
+cd (git rev-parse --show-toplevel)
+npm run setup -- --target C:\copilot-lab\skills-lab-template --profile recommended
 ```
 
 ---

--- a/tests/beginner-skills-tutorial-e2e.md
+++ b/tests/beginner-skills-tutorial-e2e.md
@@ -10,32 +10,32 @@ Verify that the beginner tutorial in `guides/the-beginner-skills-tutorial*.md` i
 
 - GitHub Copilot CLI is installed and authenticated.
 - Run from a clean clone of `everything-copilot-cli`.
-- Use fresh target directories under `C:\work-copilot\test`.
+- Use fresh target directories under `C:\copilot-lab`.
 
 ## Procedure
 
 1. Remove any old tutorial directories:
 
    ```powershell
-   Remove-Item C:\work-copilot\test\skills-lab-template -Recurse -Force -ErrorAction SilentlyContinue
-   Remove-Item C:\work-copilot\test\skills-lab-plain -Recurse -Force -ErrorAction SilentlyContinue
-   Remove-Item C:\work-copilot\test\skills-lab-guided -Recurse -Force -ErrorAction SilentlyContinue
+   Remove-Item C:\copilot-lab\skills-lab-template -Recurse -Force -ErrorAction SilentlyContinue
+   Remove-Item C:\copilot-lab\skills-lab-plain -Recurse -Force -ErrorAction SilentlyContinue
+   Remove-Item C:\copilot-lab\skills-lab-guided -Recurse -Force -ErrorAction SilentlyContinue
    ```
 
 2. Create the template directory:
 
    ```powershell
-   New-Item -ItemType Directory -Force C:\work-copilot\test\skills-lab-template | Out-Null
+   New-Item -ItemType Directory -Force C:\copilot-lab\skills-lab-template | Out-Null
    ```
 
 3. From the repository root, run:
 
    ```powershell
    npm install
-   npm run setup -- --target C:\work-copilot\test\skills-lab-template --profile recommended
+   npm run setup -- --target C:\copilot-lab\skills-lab-template --profile recommended
    ```
 
-4. In `C:\work-copilot\test\skills-lab-template`, run:
+4. In `C:\copilot-lab\skills-lab-template`, run:
 
    ```powershell
    npm init -y
@@ -57,14 +57,14 @@ Verify that the beginner tutorial in `guides/the-beginner-skills-tutorial*.md` i
 8. Copy the template project:
 
    ```powershell
-   Copy-Item C:\work-copilot\test\skills-lab-template C:\work-copilot\test\skills-lab-plain -Recurse
-   Copy-Item C:\work-copilot\test\skills-lab-template C:\work-copilot\test\skills-lab-guided -Recurse
+   Copy-Item C:\copilot-lab\skills-lab-template C:\copilot-lab\skills-lab-plain -Recurse
+   Copy-Item C:\copilot-lab\skills-lab-template C:\copilot-lab\skills-lab-guided -Recurse
    ```
 
 9. Start Copilot in `skills-lab-template`:
 
    ```powershell
-   cd C:\work-copilot\test\skills-lab-template
+   cd C:\copilot-lab\skills-lab-template
    copilot
    ```
 

--- a/tests/setup-onboarding-e2e.md
+++ b/tests/setup-onboarding-e2e.md
@@ -26,7 +26,7 @@ Verify that a fresh project can be bootstrapped from this repository and that Gi
 2. From the repository root, run:
 
    ```powershell
-   npm run setup -- --target C:\work-copilot\test\quizquiz2 --profile recommended
+   npm run setup -- --target C:\copilot-lab\quizquiz2 --profile recommended
    ```
 
 3. Confirm the install summary reports:
@@ -38,7 +38,7 @@ Verify that a fresh project can be bootstrapped from this repository and that Gi
 4. Start Copilot in the target directory:
 
    ```powershell
-   cd C:\work-copilot\test\quizquiz2
+   cd C:\copilot-lab\quizquiz2
    copilot
    ```
 


### PR DESCRIPTION
Fixes hard-coded machine-specific paths in the beginner tutorial (4 languages) and both E2E procedures. Documentation only.